### PR TITLE
Fixes website deploy to gh-pages

### DIFF
--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,2 @@
+rd /s /q _public
+node_modules/.bin/brunch build

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+rm -rf _public
+node_modules/.bin/brunch build

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -92,11 +92,10 @@ currentHashOnMaster=$(git rev-parse HEAD)
 
 # fire up nodejs and generate _public
 startPrintingYellow
-    echo "> Firing up nodejs. Ctrl+c when generations is finished."
-    echo "> (a pull request to automatize it would be welcome)"
+    echo "> Firing up nodejs which will generate static content for the website."
 stopColloringEcho
 
-./scripts/server.sh
+./scripts/build.sh
 
 # checkout gh-pages
 git checkout gh-pages


### PR DESCRIPTION
Previously part of the deploy process was to run `server.sh` script, which build the project
and run http server with `--watch` option. To continue the deploy one had to press `Ctrl + C`
combination, which was scary and unpleasent for me. I've figured out, that there is a `build`
command for `brunch` which is exactly what builds project when you call `server`  command.
I've compared folders generated with `build` and `server` commands with `diff` and they're
the same, so the script seems pretty safe.
